### PR TITLE
Fix TypeScript property errors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "multer": "^1.4.5-lts.1",
         "nodemailer": "^6.9.7",
         "openai": "^4.20.0",
-        "typescript": "^5.8.3",
         "ws": "^8.14.2"
       },
       "devDependencies": {
@@ -49,7 +48,8 @@
         "prettier": "^3.6.1",
         "tailwindcss": "^4.1.11",
         "terser": "^5.43.1",
-        "tsx": "^4.20.3"
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -7753,6 +7753,7 @@
       "version": "5.8.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,6 @@
     "multer": "^1.4.5-lts.1",
     "nodemailer": "^6.9.7",
     "openai": "^4.20.0",
-    "typescript": "^5.8.3",
     "ws": "^8.14.2"
   },
   "devDependencies": {
@@ -81,6 +80,7 @@
     "prettier": "^3.6.1",
     "tailwindcss": "^4.1.11",
     "terser": "^5.43.1",
-    "tsx": "^4.20.3"
+    "tsx": "^4.20.3",
+    "typescript": "^5.8.3"
   }
 }

--- a/src/agents/entity-extractor-agent.ts
+++ b/src/agents/entity-extractor-agent.ts
@@ -134,7 +134,7 @@ export class EntityExtractorAgent {
             content: prompt
           }
         ],
-        max_tokens: 1500,
+        maxTokens: 1500,
         temperature: 0.1
       });
 

--- a/src/agents/master-agent.ts
+++ b/src/agents/master-agent.ts
@@ -324,7 +324,7 @@ Provide a concise final reasoning (2-3 sentences).
       const response = await this.mistral.chat.complete({
         model: 'mistral-tiny',
         messages: [{ role: 'user', content: prompt }],
-        max_tokens: 300,
+        maxTokens: 300,
         temperature: 0.3
       });
       const content = response.choices[0]?.message?.content;

--- a/src/agents/response-generator-agent.ts
+++ b/src/agents/response-generator-agent.ts
@@ -229,7 +229,7 @@ export class ResponseGeneratorAgent {
       const response = await this.mistral!.chat.complete({
         model: 'mistral-tiny',
         messages,
-        max_tokens: 400,
+        maxTokens: 400,
         temperature: 0.7
       });
       


### PR DESCRIPTION
Fix build failure by using correct `maxTokens` casing for Mistral API calls.

The build was failing due to TypeScript errors related to the `max_tokens` property. While OpenAI API expects `max_tokens` (snake_case), the Mistral API client requires `maxTokens` (camelCase). This PR updates the Mistral API calls in affected files to use `maxTokens`, resolving the build issue.